### PR TITLE
More specs and some refactoring

### DIFF
--- a/src/Linnet/Compile.hs
+++ b/src/Linnet/Compile.hs
@@ -17,6 +17,7 @@ import           Control.Exception          (SomeException)
 import           Control.Monad.Trans.Reader (ReaderT (..))
 import           Data.Data                  (Proxy, Typeable)
 import           Linnet.Endpoint
+import           Linnet.Input
 import           Linnet.Internal.Coproduct
 import           Linnet.Internal.HList
 import           Linnet.Output              (outputToResponse)

--- a/src/Linnet/Decode.hs
+++ b/src/Linnet/Decode.hs
@@ -21,6 +21,7 @@ import           Data.Either.Combinators
 import qualified Data.Text                  as T
 import           Data.Text.Read             (decimal, double, rational, signed)
 import           GHC.Base                   (Symbol)
+import           Linnet.Endpoints.Entity    (Entity)
 import           Linnet.Errors
 
 class Decode (ct :: Symbol) a where
@@ -48,10 +49,10 @@ instance DecodePath Rational where
   decodePath t = rightToMaybe $ fst <$> signed rational t
 
 class DecodeEntity a where
-  decodeEntity :: B.ByteString -> Either LinnetError a
+  decodeEntity :: Entity -> B.ByteString -> Either LinnetError a
   default decodeEntity :: (BC.FromByteString a) =>
-    B.ByteString -> Either LinnetError a
-  decodeEntity = left (DecodeEntityError . BC.toByteString') . BC.runParser BC.parser
+    Entity -> B.ByteString -> Either LinnetError a
+  decodeEntity entity = left (DecodeEntityError entity . DecodeError . BC.toByteString') . BC.runParser BC.parser
 
 instance DecodeEntity B.ByteString
 
@@ -64,7 +65,7 @@ instance DecodeEntity Int
 instance DecodeEntity Double
 
 instance DecodeEntity Float where
-  decodeEntity = right realToFrac . decodeEntity @Double
+  decodeEntity entity = right realToFrac . decodeEntity @Double entity
 
 instance DecodeEntity Rational where
-  decodeEntity = right fromIntegral . decodeEntity @Integer
+  decodeEntity entity = right fromIntegral . decodeEntity @Integer entity

--- a/src/Linnet/Decode.hs
+++ b/src/Linnet/Decode.hs
@@ -52,7 +52,7 @@ class DecodeEntity a where
   decodeEntity :: Entity -> B.ByteString -> Either LinnetError a
   default decodeEntity :: (BC.FromByteString a) =>
     Entity -> B.ByteString -> Either LinnetError a
-  decodeEntity entity = left (DecodeEntityError entity . DecodeError . BC.toByteString') . BC.runParser BC.parser
+  decodeEntity entity = left (EntityNotParsed entity . DecodeError . BC.toByteString') . BC.runParser BC.parser
 
 instance DecodeEntity B.ByteString
 

--- a/src/Linnet/Endpoints/Bodies.hs
+++ b/src/Linnet/Endpoints/Bodies.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -14,27 +13,27 @@ module Linnet.Endpoints.Bodies
   , textBodyMaybe
   ) where
 
-import           Control.Monad.IO.Class (MonadIO (..))
-import qualified Data.ByteString.Lazy   as BL
-import           Linnet.ContentTypes    (ApplicationJson, TextPlain)
+import           Control.Monad.Catch     (MonadThrow, throwM)
+import           Control.Monad.IO.Class  (MonadIO (..))
+import qualified Data.ByteString.Lazy    as BL
+import           Linnet.ContentTypes     (ApplicationJson, TextPlain)
 import           Linnet.Decode
 import           Linnet.Endpoint
+import           Linnet.Endpoints.Entity
 import           Linnet.Errors
 import           Linnet.Input
 import           Linnet.Output
-import           Network.Wai            (RequestBodyLength (..),
-                                         lazyRequestBody, requestBodyLength)
-import Control.Monad.Catch (throwM, MonadThrow)
+import           Network.Wai             (RequestBodyLength (..),
+                                          lazyRequestBody, requestBodyLength)
 
 decodeBody ::
-     forall ct a. (Decode ct a)
+     forall ct a m. (Decode ct a, MonadThrow m)
   => BL.ByteString
-  -> Output a
-decodeBody =
-  (\case
-     Right a -> ok a
-     Left e -> badRequest e) .
-  decode @ct @a
+  -> m (Output a)
+decodeBody payload =
+  case decode @ct @a payload of
+    Right a -> pure $ ok a
+    Left e  -> throwM $ DecodeEntityError Body e
 
 -- | Endpoint that tries to decode body of request into some type @a@ using corresponding 'Decode' instance
 -- Always matches, but may fail with error in case:
@@ -51,19 +50,21 @@ body =
         \input ->
           let mOut =
                 case (requestBodyLength . request) input of
-                  KnownLength 0 -> throwM $ MissingEntity "body"
-                  ChunkedBody -> throwM $ MissingEntity "body"
-                  KnownLength _ -> decodeBody @ct @a <$> (liftIO . lazyRequestBody . request) input
+                  KnownLength 0 -> throwM $ MissingEntity Body
+                  ChunkedBody -> throwM $ MissingEntity Body
+                  KnownLength _ -> (liftIO . lazyRequestBody . request) input >>= decodeBody @ct @a
            in Matched {matchedReminder = input, matchedOutput = mOut}
     , toString = "body"
     }
+  where
+    entity = Body
 
 -- | Endpoint that tries to decode body of request into some type @a@ using corresponding 'Decode' instance
 -- Always matches, but may fail with error in case:
 --
 --    * There was a body decoding error
 bodyMaybe ::
-     forall ct a m. (Decode ct a, MonadIO m)
+     forall ct a m. (Decode ct a, MonadIO m, MonadThrow m)
   => Endpoint m (Maybe a)
 bodyMaybe =
   Endpoint
@@ -73,7 +74,7 @@ bodyMaybe =
                 case (requestBodyLength . request) input of
                   KnownLength 0 -> pure $ ok Nothing
                   ChunkedBody -> pure $ ok Nothing
-                  KnownLength _ -> (fmap . fmap) Just $ decodeBody @ct @a <$> (liftIO . lazyRequestBody . request) input
+                  KnownLength _ -> (fmap . fmap) Just ((liftIO . lazyRequestBody . request) input >>= decodeBody @ct @a)
            in Matched {matchedReminder = input, matchedOutput = mOut}
     , toString = "bodyMaybe"
     }
@@ -83,7 +84,7 @@ textBody :: (Decode TextPlain a, MonadIO m, MonadThrow m) => Endpoint m a
 textBody = body @TextPlain
 
 -- | Alias for bodyMaybe @TextPlain
-textBodyMaybe :: (Decode TextPlain a, MonadIO m) => Endpoint m (Maybe a)
+textBodyMaybe :: (Decode TextPlain a, MonadIO m, MonadThrow m) => Endpoint m (Maybe a)
 textBodyMaybe = bodyMaybe @TextPlain
 
 -- | Alias for body @ApplicationJson
@@ -91,5 +92,5 @@ jsonBody :: (Decode ApplicationJson a, MonadIO m, MonadThrow m) => Endpoint m a
 jsonBody = body @ApplicationJson
 
 -- | Alias for bodyMaybe @ApplicationJson
-jsonBodyMaybe :: (Decode ApplicationJson a, MonadIO m) => Endpoint m (Maybe a)
+jsonBodyMaybe :: (Decode ApplicationJson a, MonadIO m, MonadThrow m) => Endpoint m (Maybe a)
 jsonBodyMaybe = bodyMaybe @ApplicationJson

--- a/src/Linnet/Endpoints/Bodies.hs
+++ b/src/Linnet/Endpoints/Bodies.hs
@@ -33,7 +33,7 @@ decodeBody ::
 decodeBody payload =
   case decode @ct @a payload of
     Right a -> pure $ ok a
-    Left e  -> throwM $ DecodeEntityError Body e
+    Left e  -> throwM $ EntityNotParsed Body e
 
 -- | Endpoint that tries to decode body of request into some type @a@ using corresponding 'Decode' instance
 -- Always matches, but may fail with error in case:

--- a/src/Linnet/Endpoints/Cookies.hs
+++ b/src/Linnet/Endpoints/Cookies.hs
@@ -45,7 +45,7 @@ cookie name =
                 case maybeCookie of
                   Just val ->
                     case decodeEntity entity val of
-                      Left err -> throwM $ EntityNotParsed {notParsedEntity = entity, entityParsingError = err}
+                      Left err -> throwM err
                       Right v -> return $ ok v
                   _ -> throwM $ MissingEntity entity
            in Matched {matchedReminder = input, matchedOutput = output}
@@ -70,7 +70,7 @@ cookieMaybe name =
                 case maybeCookie of
                   Just val ->
                     case decodeEntity entity val of
-                      Left err -> throwM $ EntityNotParsed {notParsedEntity = entity, entityParsingError = err}
+                      Left err -> throwM err
                       Right v -> return $ ok (Just v)
                   _ -> return $ ok Nothing
            in Matched {matchedReminder = input, matchedOutput = output}

--- a/src/Linnet/Endpoints/Entity.hs
+++ b/src/Linnet/Endpoints/Entity.hs
@@ -1,0 +1,19 @@
+module Linnet.Endpoints.Entity
+  ( Entity(..)
+  ) where
+
+import qualified Data.ByteString as B
+import qualified Data.Text       as T
+
+data Entity
+  = Param
+      { entityName :: B.ByteString
+      }
+  | Header
+      { entityName :: B.ByteString
+      }
+  | Body
+  | Cookie
+      { entityName :: B.ByteString
+      }
+  deriving (Eq, Show)

--- a/src/Linnet/Endpoints/Headers.hs
+++ b/src/Linnet/Endpoints/Headers.hs
@@ -37,7 +37,7 @@ header name =
                 case maybeHeader of
                   Just val ->
                     case decodeEntity entity val of
-                      Left err -> throwM $ EntityNotParsed {notParsedEntity = entity, entityParsingError = err}
+                      Left err -> throwM err
                       Right v -> return $ ok v
                   _ -> throwM $ MissingEntity entity
            in Matched {matchedReminder = input, matchedOutput = output}
@@ -62,7 +62,7 @@ headerMaybe name =
                 case maybeHeader of
                   Just val ->
                     case decodeEntity entity val of
-                      Left err -> throwM $ EntityNotParsed {notParsedEntity = entity, entityParsingError = err}
+                      Left err -> throwM err
                       Right v -> return $ ok (Just v)
                   _ -> return $ ok Nothing
            in Matched {matchedReminder = input, matchedOutput = output}

--- a/src/Linnet/Endpoints/Methods.hs
+++ b/src/Linnet/Endpoints/Methods.hs
@@ -11,6 +11,7 @@ module Linnet.Endpoints.Methods
   ) where
 
 import           Linnet.Endpoint
+import           Linnet.Input
 import           Network.HTTP.Types
 import           Network.Wai        (requestMethod)
 

--- a/src/Linnet/Endpoints/Params.hs
+++ b/src/Linnet/Endpoints/Params.hs
@@ -63,7 +63,7 @@ paramMaybe name =
                 case maybeParam of
                   Just (Just val) ->
                     case decodeEntity entity val of
-                      Left err -> throwM $ EntityNotParsed {notParsedEntity = entity, entityParsingError = err}
+                      Left err -> throwM err
                       Right v -> return $ ok (Just v)
                   _ -> return $ ok Nothing
            in Matched {matchedReminder = input, matchedOutput = output}

--- a/src/Linnet/Endpoints/Params.hs
+++ b/src/Linnet/Endpoints/Params.hs
@@ -102,7 +102,7 @@ paramsNel ::
      forall a m. (DecodeEntity a, MonadThrow m)
   => B.ByteString
   -> Endpoint m (NonEmpty a)
-paramsNel name = mapOutput toNel $ params @a name
+paramsNel name = mapOutputM toNel $ params @a name
   where
-    toNel []    = badRequest $ MissingEntity name
-    toNel (h:t) = ok $ h :| t
+    toNel []    = throwM $ MissingEntity name
+    toNel (h:t) = return $ ok (h :| t)

--- a/src/Linnet/Endpoints/Paths.hs
+++ b/src/Linnet/Endpoints/Paths.hs
@@ -16,6 +16,7 @@ import           Data.Maybe            (maybeToList)
 import qualified Data.Text             as T
 import           Linnet.Decode
 import           Linnet.Endpoint
+import           Linnet.Input
 import           Linnet.Internal.HList
 import           Linnet.Output         (ok)
 

--- a/src/Linnet/Errors.hs
+++ b/src/Linnet/Errors.hs
@@ -4,15 +4,11 @@ module Linnet.Errors
 
 import           Control.Exception       (Exception)
 import qualified Data.ByteString         as B
-import           Data.List.NonEmpty      (NonEmpty)
+import           Data.List.NonEmpty      (NonEmpty (..), toList, (<|))
 import           Linnet.Endpoints.Entity
 
 data LinnetError
-  = DecodeEntityError
-      { nondecodableEntity :: Entity
-      , decodeEntityError  :: LinnetError
-      }
-  | MissingEntity
+  = MissingEntity
       { missingEntity :: Entity
       }
   | EntityNotParsed
@@ -26,5 +22,14 @@ data LinnetError
       { decodeError :: B.ByteString
       }
   deriving (Eq, Show)
+
+instance Semigroup LinnetError where
+  (LinnetErrors es) <> (LinnetErrors es') =
+    let (h:t) = toList es
+        (h':t') = toList es
+     in LinnetErrors $ h :| (t ++ [h] ++ t')
+  (LinnetErrors es) <> err = LinnetErrors $ err <| es
+  err <> (LinnetErrors es) = LinnetErrors $ err <| es
+  e <> e' = LinnetErrors $ e :| [e']
 
 instance Exception LinnetError

--- a/src/Linnet/Errors.hs
+++ b/src/Linnet/Errors.hs
@@ -2,20 +2,22 @@ module Linnet.Errors
   ( LinnetError(..)
   ) where
 
-import           Control.Exception  (Exception)
-import qualified Data.ByteString    as B
-import           Data.List.NonEmpty (NonEmpty)
+import           Control.Exception       (Exception)
+import qualified Data.ByteString         as B
+import           Data.List.NonEmpty      (NonEmpty)
+import           Linnet.Endpoints.Entity
 
 data LinnetError
   = DecodeEntityError
-      { decodeEntityError :: B.ByteString
+      { nondecodableEntity :: Entity
+      , decodeEntityError  :: LinnetError
       }
   | MissingEntity
-      { missingEntityName :: B.ByteString
+      { missingEntity :: Entity
       }
   | EntityNotParsed
-      { notParsedEntityName :: B.ByteString
-      , entityParsingError  :: LinnetError
+      { notParsedEntity    :: Entity
+      , entityParsingError :: LinnetError
       }
   | LinnetErrors
       { linnetErrors :: NonEmpty LinnetError

--- a/src/Linnet/Input.hs
+++ b/src/Linnet/Input.hs
@@ -1,0 +1,22 @@
+module Linnet.Input
+  ( Input(..)
+  , inputFromGet
+  ) where
+
+import qualified Data.Text          as T
+import qualified Data.Text.Encoding as TE
+import           Network.Wai        (Request, defaultRequest, pathInfo,
+                                     rawPathInfo)
+
+-- | Container for the reminder of the request path and request itself
+data Input =
+  Input
+    { reminder :: [T.Text]
+    , request  :: Request
+    }
+  deriving (Show)
+
+inputFromGet :: T.Text -> Input
+inputFromGet path = Input {request = defaultRequest {pathInfo = rem, rawPathInfo = TE.encodeUtf8 path}, reminder = rem}
+  where
+    rem = T.split (== '/') path

--- a/src/Linnet/Input.hs
+++ b/src/Linnet/Input.hs
@@ -5,8 +5,9 @@ module Linnet.Input
 
 import qualified Data.Text          as T
 import qualified Data.Text.Encoding as TE
+import           Network.HTTP.Types (QueryItem)
 import           Network.Wai        (Request, defaultRequest, pathInfo,
-                                     rawPathInfo)
+                                     queryString, rawPathInfo)
 
 -- | Container for the reminder of the request path and request itself
 data Input =
@@ -16,7 +17,9 @@ data Input =
     }
   deriving (Show)
 
-inputFromGet :: T.Text -> Input
-inputFromGet path = Input {request = defaultRequest {pathInfo = rem, rawPathInfo = TE.encodeUtf8 path}, reminder = rem}
+inputFromGet :: T.Text -> [QueryItem] -> Input
+inputFromGet path items =
+  Input
+    {request = defaultRequest {pathInfo = rem, rawPathInfo = TE.encodeUtf8 path, queryString = items}, reminder = rem}
   where
     rem = T.split (== '/') path

--- a/src/Linnet/Internal/HList.hs
+++ b/src/Linnet/Internal/HList.hs
@@ -83,6 +83,12 @@ instance Show (HList '[]) where
 instance (Show a, Show (HList as)) => Show (HList (a ': as)) where
   show (a ::: as) = show a ++ " ::: " ++ show as
 
+instance Eq (HList '[]) where
+  (==) HNil HNil = True
+
+instance (Eq a, Eq (HList as)) => Eq (HList (a ': as)) where
+  (==) (a ::: as) (a' ::: as') = a == a' && as == as'
+
 class FnToProduct fn ls out | fn ls -> out, ls out -> fn where
   fromFunction :: fn -> HList ls -> out
 

--- a/test/EndpointSpec.hs
+++ b/test/EndpointSpec.hs
@@ -7,15 +7,25 @@ module EndpointSpec
   ( spec
   ) where
 
-import           Control.Exception       (SomeException)
+import           Control.Applicative     ((<|>))
+import           Control.Exception       (SomeException, fromException,
+                                          toException)
+import           Control.Monad.Catch     (throwM)
+import           Control.Monad.IO.Class  (liftIO)
 import qualified Data.ByteString         as B
+import           Data.Either             (isLeft, lefts)
+import           Data.Function           ((&))
 import           Data.Functor.Identity
 import           Data.List               (uncons)
+import           Data.List.NonEmpty      (toList)
 import           Data.Maybe              (isNothing, maybeToList)
 import qualified Data.Text               as T
+import           Debug.Trace             (trace)
 import           Instances
 import           Linnet
 import           Linnet.Endpoint
+import           Linnet.Errors
+import           Linnet.Input
 import           Linnet.Internal.HList
 import           Linnet.Output           (withHeader)
 import           Network.HTTP.Types      (methodConnect, methodDelete,
@@ -87,5 +97,50 @@ spec =
             , property $ matchMethod methodConnect connect
             , property $ matchMethod methodTrace trace'
             ]
-    it "always match with identity instance" $
+    it "always matches with identity instance" $
       property $ \(i :: Input) -> maybeReminder (runEndpoint (zero @Identity) i) == Just i
+    it "shouldn't match if one of the endpoints has failed in (//) composition" $
+      property $ \(i :: Input, s :: T.Text) -> isNothing (maybeReminder (runEndpoint (pathAny @Identity // p' s) i))
+    it "matches if at least one of the endpoints succeed in alternative <|>" $
+      let matchOneOfTwo :: (T.Text -> Endpoint Identity (HList '[])) -> Input -> Bool
+          matchOneOfTwo f input = isNothing v || v == Just input {reminder = tail $ reminder input}
+            where
+              v = f <$> (headOption . reminder) input >>= (\e -> maybeReminder (runEndpoint e input))
+       in conjoin
+            [ property $ matchOneOfTwo (\s -> p' s <|> p' (T.reverse s))
+            , property $ matchOneOfTwo (\s -> p' (T.reverse s) <|> p' s)
+            ]
+    it "always responds with the same output if it's constant" $
+      conjoin
+        [ property $ \(t :: T.Text) ->
+            resultValueUnsafe (runEndpoint (pure t) (inputFromGet "/")) == Identity (Just t) &&
+            resultValueUnsafe (runEndpoint (lift $ pure t) (inputFromGet "/")) == Identity (Just t)
+        , property $ \(out :: Output T.Text) ->
+            resultOutputUnsafe (runEndpoint (liftOutputM $ pure out) (inputFromGet "/")) == Identity (Just out)
+        ]
+    it "handles the exception raised in a monad" $
+      property $ \(i :: Input, s :: T.Text) ->
+        monadicIO $ do
+          let e = lift (throwM @IO (TestException "test")) & handle (\(e :: TestException) -> return $ created s)
+          result <- liftIO $ runEndpoint e i & resultOutputEither
+          assert (result == Right (Just (created s)))
+    it "re-raises the exception if it wasn't handled" $
+      property $ \(i :: Input, s :: T.Text) ->
+        monadicIO $ do
+          let e :: Endpoint IO T.Text = lift (throwM @IO (TestException "test"))
+          result <- liftIO $ runEndpoint e i & resultOutputEither
+          assert (result == Left (toException $ TestException "test"))
+    it "throws MissingEntity if an item wasn't found" $ do
+      let i = inputFromGet "/"
+      let name = "test"
+      let exception = MissingEntity name
+      let (endpoints, exceptions) =
+            unzip
+              [ (param @T.Text name, exception)
+              , (T.intercalate ";" . toList <$> paramsNel @T.Text name, exception)
+              , (header @T.Text name, exception)
+              , (cookie @T.Text name, exception)
+              , (textBody @T.Text, MissingEntity "body")
+              ]
+      results <- lefts <$> mapM (\e -> runEndpoint e i & resultOutputEither) endpoints
+      map fromException results `shouldBe` Just <$> exceptions


### PR DESCRIPTION
- Add error accumulation in `productWith`
- Remove `coproduct` in favor of `Alternative.<|>`
- Rework errors report in basic endpoints, throw an exception in `MonadThrow m` instead of returning `Output.payloadError`
- Add function for the handling of errors in `m` of `Endpoint`
- Add corresponding specs