### PR TITLE
Add MethodNotAllowed 405 support

### DIFF
--- a/linnet-conduit/src/Linnet/Conduit.hs
+++ b/linnet-conduit/src/Linnet/Conduit.hs
@@ -33,7 +33,7 @@ import           Data.Data                    (Proxy (..))
 import           Data.Void                    (Void)
 import           GHC.TypeLits                 (KnownSymbol, symbolVal)
 import           Linnet
-import           Linnet.Endpoint              (EndpointResult (..))
+import           Linnet.Endpoint              (EndpointResult (..), NotMatchedReason(..))
 import           Linnet.Input                 (request)
 import           Linnet.NaturalTransformation (NaturalTransformation (..))
 import           Linnet.ToResponse
@@ -67,7 +67,7 @@ streamBody =
                         do liftIO $ pauseTimeout req
                            pure $ ok $ (fromLazyBody . lazyRequestBody) req
                     }
-                KnownLength _ -> NotMatched
+                KnownLength _ -> NotMatched Other
     , toString = "streamBody"
     }
 

--- a/linnet/src/Linnet/Compile.hs
+++ b/linnet/src/Linnet/Compile.hs
@@ -4,9 +4,12 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 module Linnet.Compile
   ( Compile(..)
@@ -14,7 +17,9 @@ module Linnet.Compile
 
 import           Control.Exception         (SomeException)
 import           Control.Monad.Catch       (MonadCatch)
-import           Control.Monad.Reader      (ReaderT(..))
+import           Control.Monad.Reader      (ReaderT (..))
+import           Data.ByteString           (intercalate)
+import qualified Data.CaseInsensitive      as CI
 import           Data.Data                 (Proxy)
 import           GHC.TypeLits              (KnownSymbol)
 import           Linnet.Endpoint
@@ -25,26 +30,55 @@ import           Linnet.Internal.HList
 import           Linnet.Output             (Output (..), outputToResponse,
                                             payloadError)
 import           Linnet.ToResponse         (ToResponse)
-import           Network.HTTP.Types        (badRequest400, status404)
+import           Network.HTTP.Types        (Method, badRequest400,
+                                            methodNotAllowed405, notFound404,
+                                            status404)
+import           Network.HTTP.Types.Header (hAllow)
 import           Network.Wai               (Request, Response, responseLBS)
+
+newtype CompileContext =
+  CompileContext
+    { allowedMethods :: [Method]
+    }
 
 class Compile cts m es where
   compile :: es -> ReaderT Request m Response
 
-instance (Monad m) => Compile CNil m (HList '[]) where
-  compile _ = ReaderT $ const notFoundResponse
+instance (Compile' cts m es) => Compile cts m es where
+  compile es = compile' @cts es (CompileContext [])
 
-instance (KnownSymbol ct, ToResponse ct a, ToResponse ct SomeException, Compile cts m (HList es), MonadCatch m) =>
-         Compile (Coproduct (Proxy ct) cts) m (HList (Endpoint m a ': es)) where
-  compile (ea ::: es) =
+class Compile' cts m es where
+  compile' :: es -> CompileContext -> ReaderT Request m Response
+
+instance (Monad m) => Compile' CNil m (HList '[]) where
+  compile' _ ctx@CompileContext {..} =
+    ReaderT $
+    const
+      (if null allowedMethods
+         then notFoundResponse
+         else methodNotAllowedResponse allowedMethods)
+
+instance (KnownSymbol ct, ToResponse ct a, ToResponse ct SomeException, Compile' cts m (HList es), MonadCatch m) =>
+         Compile' (Coproduct (Proxy ct) cts) m (HList (Endpoint m a ': es)) where
+  compile' (ea ::: es) ctx@CompileContext {..} =
     ReaderT
       (\req ->
          case runEndpoint (handle respond400 ea) (inputFromRequest req) of
            Matched _ mo -> outputToResponse @a @ct <$> mo
-           NotMatched   -> runReaderT (compile @cts es) req)
+           NotMatched r ->
+             let newContext =
+                   case r of
+                     MethodNotAllowed allowed -> ctx {allowedMethods = allowed : allowedMethods}
+                     Other -> ctx
+              in runReaderT (compile' @cts es newContext) req)
 
 notFoundResponse :: (Applicative m) => m Response
-notFoundResponse = pure $ responseLBS status404 [] mempty
+notFoundResponse = pure $ responseLBS notFound404 [] mempty
+
+methodNotAllowedResponse :: (Applicative m) => [Method] -> m Response
+methodNotAllowedResponse wouldAllow = pure $ responseLBS methodNotAllowed405 [(hAllow, headerValue)] mempty
+  where
+    headerValue = intercalate ", " wouldAllow
 
 respond400 :: (Applicative m) => LinnetError -> m (Output a)
 respond400 err = pure $ payloadError badRequest400 err

--- a/linnet/src/Linnet/Endpoints/Bodies.hs
+++ b/linnet/src/Linnet/Endpoints/Bodies.hs
@@ -49,7 +49,7 @@ body =
     { runEndpoint =
         \input ->
           case (requestBodyLength . request) input of
-            ChunkedBody -> NotMatched
+            ChunkedBody -> NotMatched Other
             KnownLength 0 -> Matched {matchedReminder = input, matchedOutput = throwM $ MissingEntity Body}
             KnownLength _ ->
               Matched
@@ -71,7 +71,7 @@ bodyMaybe =
     { runEndpoint =
         \input ->
           case (requestBodyLength . request) input of
-            ChunkedBody -> NotMatched
+            ChunkedBody -> NotMatched Other
             KnownLength 0 -> Matched {matchedReminder = input, matchedOutput = pure $ ok Nothing}
             KnownLength _ ->
               Matched

--- a/linnet/src/Linnet/Endpoints/Cookies.hs
+++ b/linnet/src/Linnet/Endpoints/Cookies.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Linnet.Endpoints.Cookies
@@ -10,13 +9,13 @@ module Linnet.Endpoints.Cookies
 import           Control.Monad.Catch     (MonadThrow, throwM)
 import qualified Data.ByteString         as B
 import qualified Data.ByteString.Char8   as C8
-import qualified Data.CaseInsensitive    as CI
 import           Linnet.Decode
 import           Linnet.Endpoint
 import           Linnet.Endpoints.Entity
 import           Linnet.Errors
 import           Linnet.Input
 import           Linnet.Output
+import           Network.HTTP.Types      (hCookie)
 import           Network.URI.Encode      (decodeByteString)
 import           Network.Wai             (requestHeaders)
 
@@ -43,7 +42,7 @@ cookie name =
   Endpoint
     { runEndpoint =
         \input ->
-          let maybeCookie = (lookup (CI.mk "Cookie") . requestHeaders . request) input >>= findCookie name
+          let maybeCookie = (lookup hCookie . requestHeaders . request) input >>= findCookie name
               output =
                 case maybeCookie of
                   Just val ->
@@ -69,7 +68,7 @@ cookieMaybe name =
   Endpoint
     { runEndpoint =
         \input ->
-          let maybeCookie = (lookup (CI.mk "Cookie") . requestHeaders . request) input >>= findCookie name
+          let maybeCookie = (lookup hCookie . requestHeaders . request) input >>= findCookie name
               output =
                 case maybeCookie of
                   Just val ->

--- a/linnet/src/Linnet/Endpoints/Methods.hs
+++ b/linnet/src/Linnet/Endpoints/Methods.hs
@@ -20,9 +20,12 @@ methodEndpoint method underlying =
   Endpoint
     { runEndpoint =
         \input ->
-          if (requestMethod . request) input == method
-            then runEndpoint underlying input
-            else NotMatched
+          let result = runEndpoint underlying input
+           in if (requestMethod . request) input == method
+                then result
+                else case result of
+                       Matched _ _ -> NotMatched (MethodNotAllowed method)
+                       skipped     -> skipped
     , toString = show method ++ " " ++ toString underlying
     }
 

--- a/linnet/src/Linnet/Endpoints/Paths.hs
+++ b/linnet/src/Linnet/Endpoints/Paths.hs
@@ -33,11 +33,11 @@ path =
     { runEndpoint =
         \input ->
           case reminder input of
-            [] -> NotMatched
+            [] -> NotMatched Other
             (h:t) ->
               case decodePath h of
                 Just v -> Matched {matchedReminder = input {reminder = t}, matchedOutput = pure $ ok v}
-                Nothing -> NotMatched
+                Nothing -> NotMatched Other
     , toString = show (typeRep (Proxy :: Proxy a))
     }
 
@@ -53,11 +53,11 @@ pathConst value =
     { runEndpoint =
         \input ->
           case reminder input of
-            [] -> NotMatched
+            [] -> NotMatched Other
             (h:t) ->
               if h == value
                 then Matched {matchedReminder = input {reminder = t}, matchedOutput = pure $ ok HNil}
-                else NotMatched
+                else NotMatched Other
     , toString = T.unpack value
     }
 
@@ -73,7 +73,7 @@ pathEmpty =
         \input ->
           case reminder input of
             [] -> Matched input (pure . ok $ HNil)
-            _  -> NotMatched
+            _  -> NotMatched Other
     , toString = "/"
     }
 

--- a/linnet/src/Linnet/ToResponse.hs
+++ b/linnet/src/Linnet/ToResponse.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -19,7 +18,7 @@ import GHC.Base (Symbol)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import Linnet.Encode (Encode(..))
 import Linnet.Internal.Coproduct (CNil, Coproduct(..))
-import Network.HTTP.Types (status200, status404)
+import Network.HTTP.Types (hContentType, status200, status404)
 import Network.Wai (Response, responseLBS)
 
 -- | Type-class to convert a value of type @a@ into Response with Content-Type of @ct@
@@ -52,7 +51,7 @@ mkResponse ::
      forall ct. (KnownSymbol ct)
   => BL.ByteString
   -> Response
-mkResponse = responseLBS status200 [("Content-Type", C8.pack $ symbolVal (Proxy :: Proxy ct))]
+mkResponse = responseLBS status200 [(hContentType, C8.pack $ symbolVal (Proxy :: Proxy ct))]
 
 data Value
   = Value

--- a/linnet/test/Instances.hs
+++ b/linnet/test/Instances.hs
@@ -282,7 +282,7 @@ instance Eq Request where
 
 instance Eq (m (Output a)) => Eq (EndpointResult m a) where
   (==) (Matched i m) (Matched i' m') = i == i' && m == m'
-  (==) NotMatched NotMatched         = True
+  (==) (NotMatched r) (NotMatched r')         = r == r'
   (==) _ _                           = False
 
 instance Eq (m (Output a)) => Eq (Endpoint m a) where

--- a/linnet/test/Util.hs
+++ b/linnet/test/Util.hs
@@ -22,8 +22,8 @@ headOption []    = Nothing
 headOption (h:t) = Just h
 
 resultOutputUnsafe :: (Applicative m) => EndpointResult m a -> m (Maybe (Output a))
-resultOutputUnsafe (Matched _ m) = fmap Just m
-resultOutputUnsafe NotMatched    = pure Nothing
+resultOutputUnsafe (Matched _ m)  = fmap Just m
+resultOutputUnsafe (NotMatched _) = pure Nothing
 
 resultValueUnsafe :: (Applicative m) => EndpointResult m a -> m (Maybe a)
 resultValueUnsafe (Matched _ m) =
@@ -32,12 +32,12 @@ resultValueUnsafe (Matched _ m) =
        Output _ (Payload a) _ -> Just a
        _ -> Nothing)
     m
-resultValueUnsafe NotMatched = pure Nothing
+resultValueUnsafe (NotMatched _) = pure Nothing
 
 resultOutputEither :: (MonadCatch m) => EndpointResult m a -> m (Either SomeException (Maybe (Output a)))
 resultOutputEither endpointResult =
   case endpointResult of
-    NotMatched -> pure $ Right Nothing
+    NotMatched _ -> pure $ Right Nothing
     Matched {matchedOutput = m} -> catchAll (fmap (Right . Just) m) (pure . Left)
 
 checkLaws :: String -> Laws -> SpecWith ()


### PR DESCRIPTION
Add reason field to `NotMatched` case of `EndpointResult` that carries the information about mismatch event to derive 405 error later in the compilation.