### PR TITLE
Add Content-Type negotiation support

### DIFF
--- a/linnet/package.yaml
+++ b/linnet/package.yaml
@@ -28,6 +28,7 @@ dependencies:
   - exceptions
   - uri-encode
   - mtl
+  - http-media
 
 library:
   source-dirs: src

--- a/linnet/src/Linnet.hs
+++ b/linnet/src/Linnet.hs
@@ -94,6 +94,9 @@ module Linnet
   , ApplicationJson
   , TextHtml
   , TextPlain
+  -- * Content-Type negotiation
+  , NotAcceptable406
+  , (:+:)
   ) where
 
 import           Linnet.Bootstrap
@@ -102,7 +105,9 @@ import           Linnet.Decode
 import           Linnet.Encode
 import           Linnet.Endpoint
 import           Linnet.Endpoints
+import           Linnet.Internal.Coproduct ((:+:))
 import           Linnet.Output
+import           Linnet.ToResponse         (NotAcceptable406)
 import           Network.Wai.Handler.Warp
 -- $helloWorld
 -- Hello @name@ example using warp server:

--- a/linnet/src/Linnet/ContentTypes.hs
+++ b/linnet/src/Linnet/ContentTypes.hs
@@ -6,11 +6,13 @@ module Linnet.ContentTypes
   , ApplicationJson
   ) where
 
+import Data.Data (Proxy)
+
 -- | Content-Type literal for @text/html@ encoding
-type TextHtml = "text/html"
+type TextHtml = Proxy "text/html"
 
 -- | Content-Type literal for @text/plain@ encoding
-type TextPlain = "text/plain"
+type TextPlain = Proxy "text/plain"
 
 -- | Content-Type literal for @application/json@ encoding
-type ApplicationJson = "application/json"
+type ApplicationJson = Proxy "application/json"

--- a/linnet/src/Linnet/Decode.hs
+++ b/linnet/src/Linnet/Decode.hs
@@ -28,7 +28,7 @@ import           Linnet.Errors
 -- | Decoding of HTTP request payload into some type @a@.
 -- Phantom type @ct@ guarantees that compiler checks support of decoding some @a@ from content of given @Content-Type@
 -- by looking for specific @Decode@ instance.
-class Decode (ct :: Symbol) a where
+class Decode ct a where
   decode :: BL.ByteString -> Either LinnetError a
 
 class DecodePath a where

--- a/linnet/src/Linnet/Encode.hs
+++ b/linnet/src/Linnet/Encode.hs
@@ -22,7 +22,7 @@ import           Linnet.ContentTypes
 -- | Encoding of some type @a@ into payload of HTTP response
 -- Phantom type @ct@ guarantees that compiler checks support of encoding of some @a@ into content of given @Content-Type@
 -- by looking for specific @Encode@ instance.
-class Encode (ct :: Symbol) a where
+class Encode ct a where
   encode :: a -> BL.ByteString
 
 instance Encode TextPlain BL.ByteString where

--- a/linnet/src/Linnet/Internal/Coproduct.hs
+++ b/linnet/src/Linnet/Internal/Coproduct.hs
@@ -8,10 +8,12 @@
 {-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
 
 module Linnet.Internal.Coproduct
   ( Coproduct(..)
+  , (:+:)
   , CNil
   , AdjoinCoproduct(..)
   ) where
@@ -20,6 +22,11 @@ data CNil
 
 instance Eq CNil where
   (==) _ _ = True
+
+-- | Type operator for 'Coproduct' type 
+type a :+: b = Coproduct a b
+
+infixr 9 :+:
 
 data Coproduct a b where
   Inl :: a -> Coproduct a b

--- a/linnet/src/Linnet/ToResponse.hs
+++ b/linnet/src/Linnet/ToResponse.hs
@@ -6,52 +6,60 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Linnet.ToResponse
   ( ToResponse(..)
+  , Negotiable(..)
+  , NotAcceptable406
   ) where
 
+import Control.Applicative ((<|>))
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy as BL
+import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy(..))
 import GHC.Base (Symbol)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import Linnet.Encode (Encode(..))
-import Linnet.Internal.Coproduct (CNil, Coproduct(..))
-import Network.HTTP.Types (hContentType, status200, status404)
+import Linnet.Internal.Coproduct ((:+:), CNil, Coproduct(..))
+import Network.HTTP.Media (MediaType, Quality, (//), matchQuality, matches)
+import Network.HTTP.Types (Header, Status, hContentType, notAcceptable406, status200, status404)
 import Network.Wai (Response, responseLBS)
 
 -- | Type-class to convert a value of type @a@ into Response with Content-Type of @ct@
-class ToResponse (ct :: Symbol) a where
-  toResponse :: a -> Response
+class ToResponse ct a where
+  toResponse :: Status -> [Header] -> a -> Response
 
 instance {-# OVERLAPPABLE #-} (ToResponse' (ValueT a) ct a) => ToResponse ct a where
   toResponse = toResponse' @(ValueT a) @ct
 
-class ToResponse' (value :: Value) (ct :: Symbol) a where
-  toResponse' :: a -> Response
+class ToResponse' (value :: Value) ct a where
+  toResponse' :: Status -> [Header] -> a -> Response
 
-instance (Encode ct a, KnownSymbol ct) => ToResponse' 'Value ct a where
-  toResponse' a = mkResponse @ct $ encode @ct a
+instance (Encode (Proxy ct) a, KnownSymbol ct) => ToResponse' 'Value (Proxy ct) a where
+  toResponse' status headers a = mkResponse @ct status headers $ encode @(Proxy ct) a
 
 instance ToResponse' 'ResponseValue ct Response where
-  toResponse' = id
+  toResponse' _ _ = id
 
-instance (KnownSymbol ct) => ToResponse' 'UnitValue ct () where
-  toResponse' _ = mkResponse @ct mempty
+instance (KnownSymbol ct) => ToResponse' 'UnitValue (Proxy ct) () where
+  toResponse' status headers _ = mkResponse @ct status headers mempty
 
 instance ToResponse' 'CNilValue ct CNil where
-  toResponse' _ = responseLBS status404 [] mempty
+  toResponse' _ _ _ = responseLBS status404 [] mempty
 
 instance (ToResponse ct a, ToResponse ct b) => ToResponse' 'CoproductValue ct (Coproduct a b) where
-  toResponse' (Inl a) = toResponse @ct a
-  toResponse' (Inr b) = toResponse @ct b
+  toResponse' status headers (Inl a) = toResponse @ct status headers a
+  toResponse' status headers (Inr b) = toResponse @ct status headers b
 
 mkResponse ::
      forall ct. (KnownSymbol ct)
-  => BL.ByteString
+  => Status
+  -> [Header]
+  -> BL.ByteString
   -> Response
-mkResponse = responseLBS status200 [(hContentType, C8.pack $ symbolVal (Proxy :: Proxy ct))]
+mkResponse status headers = responseLBS status ((hContentType, C8.pack $ symbolVal (Proxy :: Proxy ct)) : headers)
 
 data Value
   = Value
@@ -66,3 +74,55 @@ type family ValueT (a :: *) :: Value where
   ValueT Response = 'ResponseValue
   ValueT () = 'UnitValue
   ValueT _ = 'Value
+
+type ToResponseF a = Status -> [Header] -> a -> Response
+
+-- | Type-class that enables Content-Type negotiation between client and server baked by instances of 'ToResponse'.
+class Negotiable cts a where
+  negotiate :: [Quality MediaType] -> Maybe (MediaType, ToResponseF a) -> ToResponseF a
+
+instance (Negotiable' (ContentTypeValueT cts) cts a) => Negotiable cts a where
+  negotiate = negotiate' @(ContentTypeValueT cts) @cts
+
+class Negotiable' (t :: ContentTypeValue) cts a where
+  negotiate' :: [Quality MediaType] -> Maybe (MediaType, ToResponseF a) -> ToResponseF a
+
+instance (KnownSymbol c, ToResponse (Proxy c) a, Negotiable t a) =>
+         Negotiable' 'ContentTypeCoproduct (Proxy c :+: t) a where
+  negotiate' accept bestMatch = acceptMatcher accept
+    where
+      acceptMatcher mediaType =
+        let value = C8.pack $ symbolVal (Proxy :: Proxy c)
+            [p, s] = C8.split '/' value
+            mt = p // s
+            bestMatchExists = do
+              (bestMatchMediaType, fn) <- bestMatch
+              match <- matchQuality [bestMatchMediaType, mt] mediaType
+              if match == bestMatchMediaType
+                then pure $ negotiate @t mediaType bestMatch
+                else pure $ negotiate @t mediaType (Just (match, toResponse @(Proxy c)))
+            bestMatchUnknown = do
+              match <- matchQuality [mt] mediaType
+              pure $ negotiate @t mediaType (Just (match, toResponse @(Proxy c)))
+            noMatchExists = negotiate @t mediaType Nothing
+         in fromMaybe noMatchExists (bestMatchExists <|> bestMatchUnknown)
+
+instance Negotiable' 'ContentTypeNegotiationFailed NotAcceptable406 a where
+  negotiate' _ (Just (_, fn)) = fn
+  negotiate' _ Nothing = \_ _ _ -> responseLBS notAcceptable406 [] mempty
+
+instance ToResponse cts a => Negotiable' 'ContentTypeValue cts a where
+  negotiate' _ _ = toResponse @cts
+
+data ContentTypeValue
+  = ContentTypeValue
+  | ContentTypeNegotiationFailed
+  | ContentTypeCoproduct
+
+type family ContentTypeValueT ct :: ContentTypeValue where
+  ContentTypeValueT (Coproduct _ _) = 'ContentTypeCoproduct
+  ContentTypeValueT NotAcceptable406 = 'ContentTypeNegotiationFailed
+  ContentTypeValueT _ = 'ContentTypeValue
+
+-- | Uninhabited type to signal the need of 406 error during Content-Type negotiation
+data NotAcceptable406

--- a/linnet/test/EncodeLaws.hs
+++ b/linnet/test/EncodeLaws.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
@@ -11,6 +10,7 @@ module EncodeLaws
   ) where
 
 import           Data.ByteString.Conversion (ToByteString, toByteString)
+import           Data.Data                  (Proxy)
 import           GHC.Base                   (Symbol)
 import           Linnet                     (TextPlain)
 import           Linnet.Encode
@@ -18,7 +18,7 @@ import           Test.QuickCheck            (Arbitrary, property)
 import           Test.QuickCheck.Classes    (Laws (..))
 
 encodeLaws ::
-     forall a (ct :: Symbol). (ToByteString a, Encode ct a, Arbitrary a, Show a)
+     forall a ct . (ToByteString a, Encode ct a, Arbitrary a, Show a)
   => Laws
 encodeLaws = Laws "Encode" properties
   where


### PR DESCRIPTION
- Re-work `ToResponse` type class to also take status and headers as input
- Replace Content-Type types with `Proxy` instead of straight literals
- Add type operator `a :+: b = Coproduct a b`
- Add Content-Type negotiation baked by `Coproduct`