### PR TITLE
Add Endpoint tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ import Control.Exception (SomeException)
 import Data.Function ((&))
 import Data.Text (Text, append)
 import Linnet
-import Network.Wai.Handler.Warp (run)
 
 -- It's necessary to define encoding of exceptions for content-type "text/plain". Here it returns no content
 instance Encode TextPlain SomeException where

--- a/doc/01-endpoint.md
+++ b/doc/01-endpoint.md
@@ -10,7 +10,7 @@ The foundation of Linnet library is `Endpoint` data type:
 data Endpoint (m :: * -> *) a =
   Endpoint
     { runEndpoint :: Input -> EndpointResult m a
-    , toString    :: String
+    , toString    :: Text
     }
 ```
 
@@ -21,6 +21,7 @@ in `Input` and either matches with some output `m a` or doesn't match the reques
 data EndpointResult (m :: * -> *) a
   = Matched
       { matchedReminder :: Input
+      , matchedTrace    :: Trace
       , matchedOutput   :: m (Output a)
       }
   | NotMatched
@@ -109,3 +110,8 @@ nameEndpoint = get(param @Text "name") ~> (\name -> return $ created ("Name: " `
 ```
 
 Strictly speaking, `~>` operator is just an inverted alias of `mapOutputM` function.
+
+# Related topics
+- [Matching a request](02-request-match.html)
+- [Encode & Decode](04-encode-decode.html)
+- [Run Endpoint](06-run-endpoint.html)

--- a/doc/02-request-match.md
+++ b/doc/02-request-match.md
@@ -239,3 +239,8 @@ cookieMaybeEndpoint = get(cookieMaybe @Int "cookieName")
 ```
 
 Mind that `cookieName` is case-sensitive.
+
+# Related topics
+- [Endpoint](01-endpoint.html)
+- [Working with JSON](07-json.html)
+- [Streaming](08-streaming.html)

--- a/doc/03-output.md
+++ b/doc/03-output.md
@@ -46,3 +46,6 @@ responseOutput = ok(responseLBS status404 [] mempty)
 ```
 
 Mind that response status is overridden with `Output` status.
+
+# Related topics
+- [Endpoint](01-endpoint.html)

--- a/doc/04-encode-decode.md
+++ b/doc/04-encode-decode.md
@@ -51,3 +51,7 @@ class Decode (ct :: Symbol) a where
 
 And again, Content-Type of expected request is encoded as phantom type `ct` to ensure that correct decoder exists in
 compile-time.
+
+# Related topics
+- [Output](03-output.html)
+- [Run Endpoint](06-run-endpoint.html)

--- a/doc/07-json.md
+++ b/doc/07-json.md
@@ -16,3 +16,8 @@ import Linnet.Aeson
 
 Usually, it's a place of invocation of `Bodies.bodyJson` for decoding a request
 and `Bootstrap.compile` for encoding a response.
+
+# Related topics
+- [Matching a request](02-request-match.html)
+- [Encode & Decode](04-encode-decode.html)
+- [Run Endpoint](06-run-endpoint.html)

--- a/doc/08-streaming.md
+++ b/doc/08-streaming.md
@@ -18,4 +18,8 @@ with newline symbol
 - `streamBody :: Endpoint m (ConduitT BL.ByteString BL.ByteString m ())` endpoint
 
 First two instances practically allow to return `ConduitT () a m ()` from endpoints in case if `Encode ct a` is defined.
-Linnet runs stream on itself converting it into streaming response with the help of `NatureTransformation m IO` type class.  
+Linnet runs stream on itself converting it into streaming response with the help of `NatureTransformation m IO` type class.
+
+# Related topics
+- [Matching a request](02-request-match.html)
+- [Encode & Decode](04-encode-decode.html)

--- a/doc/09-tracing.md
+++ b/doc/09-tracing.md
@@ -1,0 +1,42 @@
+---
+title: Endpoint Tracing
+---
+
+# Endpoint Tracing
+
+On closer inspection, turns out that `Linnet.Compiled m` is an alias to:
+```haskell
+ type Compiled m = ReaderT (WriterT Trace m) Request (Either SomeException Response) 
+```
+
+Beside returning an `Either` that could be exception or response, the result of reader is also `WriterT Trace m` monad.  
+The `Trace` here is a list `[Text]` that carries the information about matched `path*` endpoints. This could be useful
+in measuring stats and/or logging of each endpoint for later analysis:
+
+```haskell top
+{-# LANGUAGE OverloadedStrings #-}
+
+import Control.Monad.IO.Class          (MonadIO(..))
+import Control.Monad.Trans.Reader      (ReaderT(..))
+import Control.Monad.Trans.Writer.Lazy (listen)
+import Data.Time.Clock.System          (SystemTime(..), getSystemTime)
+import Data.Text                       (unpack, intercalate)
+import Linnet
+
+naiveStats :: Compiled IO -> Compiled IO
+naiveStats compiled =
+    ReaderT $
+    (\req -> do
+        let now = liftIO $ systemNanoseconds <$> getSystemTime
+        start <- now
+        (result, trace) <- listen $ runReaderT compiled req
+        stop <- now
+        liftIO $ putStrLn $ "Time taken by " ++ (unpack (intercalate "/" trace)) ++ " is: " ++ show (stop - start)
+        return result
+    )
+``` 
+
+
+
+# Related topics
+- [Run Endpoint](06-run-endpoint.html)

--- a/examples/stack.yaml.lock
+++ b/examples/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 523878
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/3.yaml
-    sha256: 470c46c27746a48c7c50f829efc0cf00112787a7804ee4ac7a27754658f6d92c
-  original: lts-14.3
+    size: 523884
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/4.yaml
+    sha256: 16f24be248b42c9e16d59db84378836b1e7c239448a041cae46d32daffa45a8b
+  original: lts-14.4

--- a/linnet-conduit/src/Linnet/Conduit.hs
+++ b/linnet-conduit/src/Linnet/Conduit.hs
@@ -63,6 +63,7 @@ streamBody =
                 ChunkedBody ->
                   Matched
                     { matchedReminder = input
+                    , matchedTrace = []
                     , matchedOutput =
                         do liftIO $ pauseTimeout req
                            pure $ ok $ (fromLazyBody . lazyRequestBody) req

--- a/linnet-conduit/test/ConduitSpec.hs
+++ b/linnet-conduit/test/ConduitSpec.hs
@@ -55,7 +55,7 @@ spec =
                       inputFromRequest $
                       defaultRequest {requestBodyLength = ChunkedBody, requestBody = atomicModifyIORef ref getChunk}
                 let endpoint = streamBody @IO ~> (\stream -> ok <$> runConduit (stream .| sinkList))
-                let (Matched _ mOut) = runEndpoint endpoint streamed
+                let (Matched _ _ mOut) = runEndpoint endpoint streamed
                 output <- liftIO mOut
                 assert $ output == ok (map BL.fromStrict nonEmpty)
     describe "ToResponse conduit" $ do

--- a/linnet/package.yaml
+++ b/linnet/package.yaml
@@ -29,6 +29,7 @@ dependencies:
   - uri-encode
   - mtl
   - http-media
+  - time
 
 library:
   source-dirs: src

--- a/linnet/src/Linnet.hs
+++ b/linnet/src/Linnet.hs
@@ -84,6 +84,7 @@ module Linnet
   , serviceUnavailable
   , gatewayTimeout
   -- * Compiling an endpoint
+  , Compiled
   , bootstrap
   , serve
   , compile
@@ -100,6 +101,7 @@ module Linnet
   ) where
 
 import           Linnet.Bootstrap
+import           Linnet.Compile            (Compiled)
 import           Linnet.ContentTypes
 import           Linnet.Decode
 import           Linnet.Encode

--- a/linnet/src/Linnet/Decode.hs
+++ b/linnet/src/Linnet/Decode.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE UndecidableInstances  #-}
@@ -21,7 +20,6 @@ import           Data.Either.Combinators
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as TE
 import           Data.Text.Read             (decimal, double, rational, signed)
-import           GHC.Base                   (Symbol)
 import           Linnet.Endpoints.Entity    (Entity)
 import           Linnet.Errors
 

--- a/linnet/src/Linnet/Encode.hs
+++ b/linnet/src/Linnet/Encode.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 module Linnet.Encode
@@ -16,7 +15,6 @@ import           Data.Text                  as TS
 import           Data.Text.Encoding         as TSE
 import           Data.Text.Lazy             as TL
 import           Data.Text.Lazy.Encoding    as TLE
-import           GHC.Base                   (Symbol)
 import           Linnet.ContentTypes
 
 -- | Encoding of some type @a@ into payload of HTTP response

--- a/linnet/src/Linnet/Endpoints/Bodies.hs
+++ b/linnet/src/Linnet/Endpoints/Bodies.hs
@@ -50,10 +50,12 @@ body =
         \input ->
           case (requestBodyLength . request) input of
             ChunkedBody -> NotMatched Other
-            KnownLength 0 -> Matched {matchedReminder = input, matchedOutput = throwM $ MissingEntity Body}
+            KnownLength 0 ->
+              Matched {matchedReminder = input, matchedTrace = [], matchedOutput = throwM $ MissingEntity Body}
             KnownLength _ ->
               Matched
                 { matchedReminder = input
+                , matchedTrace = []
                 , matchedOutput = (liftIO . strictRequestBody . request) input >>= decodeBody @ct @a
                 }
     , toString = "body"
@@ -72,10 +74,11 @@ bodyMaybe =
         \input ->
           case (requestBodyLength . request) input of
             ChunkedBody -> NotMatched Other
-            KnownLength 0 -> Matched {matchedReminder = input, matchedOutput = pure $ ok Nothing}
+            KnownLength 0 -> Matched {matchedReminder = input, matchedTrace = [], matchedOutput = pure $ ok Nothing}
             KnownLength _ ->
               Matched
                 { matchedReminder = input
+                , matchedTrace = []
                 , matchedOutput =
                     (fmap . fmap) Just ((liftIO . strictRequestBody . request) input >>= decodeBody @ct @a)
                 }

--- a/linnet/src/Linnet/Endpoints/Cookies.hs
+++ b/linnet/src/Linnet/Endpoints/Cookies.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Linnet.Endpoints.Cookies
@@ -9,6 +10,8 @@ module Linnet.Endpoints.Cookies
 import           Control.Monad.Catch     (MonadThrow, throwM)
 import qualified Data.ByteString         as B
 import qualified Data.ByteString.Char8   as C8
+import           Data.Text               (append)
+import qualified Data.Text.Encoding      as TE
 import           Linnet.Decode
 import           Linnet.Endpoint
 import           Linnet.Endpoints.Entity
@@ -50,8 +53,8 @@ cookie name =
                       Left err -> throwM err
                       Right v  -> return $ ok v
                   _ -> throwM $ MissingEntity entity
-           in Matched {matchedReminder = input, matchedOutput = output}
-    , toString = "cookie " ++ C8.unpack name
+           in Matched {matchedReminder = input, matchedTrace = [], matchedOutput = output}
+    , toString = "cookie " `append` TE.decodeUtf8 name
     }
   where
     entity = Cookie name
@@ -76,8 +79,8 @@ cookieMaybe name =
                       Left err -> throwM err
                       Right v  -> return $ ok (Just v)
                   _ -> return $ ok Nothing
-           in Matched {matchedReminder = input, matchedOutput = output}
-    , toString = "cookieMaybe " ++ C8.unpack name
+           in Matched {matchedReminder = input, matchedTrace = [], matchedOutput = output}
+    , toString = "cookieMaybe " `append` TE.decodeUtf8 name
     }
   where
     entity = Header name

--- a/linnet/src/Linnet/Endpoints/Headers.hs
+++ b/linnet/src/Linnet/Endpoints/Headers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Linnet.Endpoints.Headers
@@ -7,8 +8,9 @@ module Linnet.Endpoints.Headers
 
 import           Control.Monad.Catch     (MonadThrow, throwM)
 import qualified Data.ByteString         as B
-import qualified Data.ByteString.Char8   as C8
 import qualified Data.CaseInsensitive    as CI
+import           Data.Text               (append)
+import qualified Data.Text.Encoding      as TE
 import           Linnet.Decode
 import           Linnet.Endpoint
 import           Linnet.Endpoints.Entity
@@ -41,8 +43,8 @@ header name =
                       Left err -> throwM err
                       Right v  -> return $ ok v
                   _ -> throwM $ MissingEntity entity
-           in Matched {matchedReminder = input, matchedOutput = output}
-    , toString = "header " ++ C8.unpack name
+           in Matched {matchedReminder = input, matchedTrace = [], matchedOutput = output}
+    , toString = "header " `append` TE.decodeUtf8 name
     }
   where
     entity = Header name
@@ -67,8 +69,8 @@ headerMaybe name =
                       Left err -> throwM err
                       Right v  -> return $ ok (Just v)
                   _ -> return $ ok Nothing
-           in Matched {matchedReminder = input, matchedOutput = output}
-    , toString = "headerMaybe " ++ C8.unpack name
+           in Matched {matchedReminder = input, matchedTrace = [], matchedOutput = output}
+    , toString = "headerMaybe " `append` TE.decodeUtf8 name
     }
   where
     entity = Header name

--- a/linnet/src/Linnet/Endpoints/Methods.hs
+++ b/linnet/src/Linnet/Endpoints/Methods.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Linnet.Endpoints.Methods
   ( get
   , post
@@ -10,6 +12,7 @@ module Linnet.Endpoints.Methods
   , options
   ) where
 
+import           Data.Text          (append, pack)
 import           Linnet.Endpoint
 import           Linnet.Input
 import           Network.HTTP.Types
@@ -24,9 +27,9 @@ methodEndpoint method underlying =
            in if (requestMethod . request) input == method
                 then result
                 else case result of
-                       Matched _ _ -> NotMatched (MethodNotAllowed method)
-                       skipped     -> skipped
-    , toString = show method ++ " " ++ toString underlying
+                       Matched {} -> NotMatched (MethodNotAllowed method)
+                       skipped    -> skipped
+    , toString = pack (show method) `append` " " `append` toString underlying
     }
 
 -- | Turn endpoint into one that matches only for GET requests

--- a/linnet/src/Linnet/Endpoints/Params.hs
+++ b/linnet/src/Linnet/Endpoints/Params.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Linnet.Endpoints.Params
@@ -10,9 +11,10 @@ module Linnet.Endpoints.Params
 
 import           Control.Monad.Catch     (MonadThrow, throwM)
 import qualified Data.ByteString         as B
-import qualified Data.ByteString.Char8   as C8
 import           Data.Either             (partitionEithers)
 import           Data.List.NonEmpty      (NonEmpty (..), nonEmpty)
+import           Data.Text               (append)
+import qualified Data.Text.Encoding      as TE
 import           Linnet.Decode
 import           Linnet.Endpoint
 import           Linnet.Endpoints.Entity
@@ -43,8 +45,8 @@ param name =
                       Left err -> throwM err
                       Right v  -> return $ ok v
                   _ -> throwM $ MissingEntity entity
-           in Matched {matchedReminder = input, matchedOutput = output}
-    , toString = "param " ++ C8.unpack name
+           in Matched {matchedReminder = input, matchedTrace = [], matchedOutput = output}
+    , toString = "param " `append` TE.decodeUtf8 name
     }
   where
     entity = Param name
@@ -69,8 +71,8 @@ paramMaybe name =
                       Left err -> throwM err
                       Right v  -> return $ ok (Just v)
                   _ -> return $ ok Nothing
-           in Matched {matchedReminder = input, matchedOutput = output}
-    , toString = "paramMaybe " ++ C8.unpack name
+           in Matched {matchedReminder = input, matchedTrace = [], matchedOutput = output}
+    , toString = "paramMaybe " `append` TE.decodeUtf8 name
     }
   where
     entity = Param name
@@ -98,8 +100,8 @@ params name =
                 case nonEmpty errors of
                   Just es -> throwM $ LinnetErrors es
                   Nothing -> return $ ok values
-           in Matched {matchedReminder = input, matchedOutput = output}
-    , toString = "params " ++ C8.unpack name
+           in Matched {matchedReminder = input, matchedTrace = [], matchedOutput = output}
+    , toString = "params " `append` TE.decodeUtf8 name
     }
   where
     entity = Param name

--- a/linnet/src/Linnet/Output.hs
+++ b/linnet/src/Linnet/Output.hs
@@ -47,9 +47,6 @@ import           Control.Exception         (Exception, SomeException,
 import           Control.Monad.Catch       (MonadThrow (..))
 import qualified Data.ByteString           as B
 import qualified Data.CaseInsensitive      as CI
-import           Data.Data                 (Proxy)
-import           GHC.TypeLits              (KnownSymbol)
-import           Linnet.ToResponse         (ToResponse (..))
 import           Network.HTTP.Types        (Header)
 import           Network.HTTP.Types.Status
 import           Network.Wai
@@ -86,6 +83,7 @@ instance Functor Output where
   fmap _ (Output status NoPayload headers) = Output status NoPayload headers
   fmap _ (Output status (ErrorPayload e) headers) = Output status (ErrorPayload e) headers
 
+-- This applicative isn't lawful due to the HTTP status. There is no logical way to combine two HTTP statuses
 instance Applicative Output where
   pure = ok
   (<*>) (Output _ (Payload f) _) (Output status (Payload a) headers) =
@@ -98,6 +96,7 @@ instance Applicative Output where
   (<*>) _ (Output status (ErrorPayload e) headers) =
     Output {outputStatus = status, outputPayload = ErrorPayload e, outputHeaders = headers}
 
+-- This monad isn't lawful due to the HTTP status. There is no logical way to combine two HTTP statuses
 instance Monad Output where
   (>>=) (Output _ (Payload a) _) f = f a
   (>>=) (Output status NoPayload headers) _ =

--- a/linnet/src/Linnet/ToResponse.hs
+++ b/linnet/src/Linnet/ToResponse.hs
@@ -19,12 +19,11 @@ import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy as BL
 import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy(..))
-import GHC.Base (Symbol)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import Linnet.Encode (Encode(..))
 import Linnet.Internal.Coproduct ((:+:), CNil, Coproduct(..))
-import Network.HTTP.Media (MediaType, Quality, (//), matchQuality, matches)
-import Network.HTTP.Types (Header, Status, hContentType, notAcceptable406, status200, status404)
+import Network.HTTP.Media (MediaType, Quality, (//), matchQuality)
+import Network.HTTP.Types (Header, Status, hContentType, notAcceptable406, status404)
 import Network.Wai (Response, responseLBS)
 
 -- | Type-class to convert a value of type @a@ into Response with Content-Type of @ct@
@@ -96,7 +95,7 @@ instance (KnownSymbol c, ToResponse (Proxy c) a, Negotiable t a) =>
             [p, s] = C8.split '/' value
             mt = p // s
             bestMatchExists = do
-              (bestMatchMediaType, fn) <- bestMatch
+              (bestMatchMediaType, _) <- bestMatch
               match <- matchQuality [bestMatchMediaType, mt] mediaType
               if match == bestMatchMediaType
                 then pure $ negotiate @t mediaType bestMatch

--- a/linnet/test/BodySpec.hs
+++ b/linnet/test/BodySpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
@@ -18,6 +19,7 @@ import           Debug.Trace                (trace)
 import           EntityEndpointLaws
 import           Instances
 import           Linnet
+import           Linnet.Endpoint            (EndpointResult (..))
 import           Linnet.Endpoints.Entity
 import           Linnet.Errors
 import           Linnet.Input
@@ -75,3 +77,10 @@ spec = do
     let e = textBodyMaybe @Foo @IO
     result <- resultOutputEither (runEndpoint e withEmptyBody)
     result `shouldBe` (Right $ Just $ ok Nothing)
+  it "returns no trace" $
+    property $ \(foo :: Foo) ->
+      monadicIO $ do
+        let e = textBody @Foo @IO
+        mvar <- liftIO $ newMVar (show foo)
+        let Matched {..} = runEndpoint e (withBody mvar)
+        assert $ null matchedTrace

--- a/linnet/test/EndpointSpec.hs
+++ b/linnet/test/EndpointSpec.hs
@@ -13,6 +13,7 @@ import           Control.Exception         (SomeException, fromException,
 import           Control.Monad.Catch       (throwM)
 import           Control.Monad.IO.Class    (liftIO)
 import qualified Data.ByteString           as B
+import           Data.Data                 (Proxy (..))
 import           Data.Either               (isLeft, lefts)
 import           Data.Function             ((&))
 import           Data.Functor.Identity
@@ -38,11 +39,13 @@ import           Network.HTTP.Types        (methodConnect, methodDelete,
 import           Network.Wai               (requestMethod)
 import           Test.Hspec
 import           Test.QuickCheck           (conjoin, property)
+import           Test.QuickCheck.Classes   (applicativeLaws)
 import           Test.QuickCheck.Monadic   (assert, monadicIO, run)
 import           Util
 
 spec :: Spec
 spec = do
+  checkLaws "Endpoint" $ applicativeLaws (Proxy :: Proxy (Endpoint IO))
   checkLaws "Text" $ extractPathLaws @T.Text
   checkLaws "Int" $ extractPathLaws @Int
   it "supports simple fmap" $

--- a/linnet/test/ExtractPathLaws.hs
+++ b/linnet/test/ExtractPathLaws.hs
@@ -7,14 +7,15 @@ module ExtractPathLaws
   ( extractPathLaws
   ) where
 
-import           Data.Data               (Typeable)
+import           Data.Data               (Proxy (..), Typeable, typeRep)
 import           Data.Function           ((&))
 import           Data.Functor.Identity   (Identity (..))
 import           Data.Maybe              (isNothing, maybeToList)
+import           Data.Text               (pack)
 import           Instances
 import           Linnet
 import           Linnet.Decode
-import           Linnet.Endpoint         (maybeReminder)
+import           Linnet.Endpoint         (maybeReminder, maybeTrace)
 import           Linnet.Input            (Input (..))
 import           Test.QuickCheck         (Arbitrary, property)
 import           Test.QuickCheck.Classes (Laws (..))
@@ -32,7 +33,9 @@ extractPathLaws = Laws "ExtractPath" properties
         let result = runEndpoint one i
             v = (headOption . reminder) i >>= decodePath @a
          in resultValueUnsafe result == Identity v &&
-            (isNothing v || maybeReminder result == Just i {reminder = (tail . reminder) i})
+            (isNothing v ||
+             (maybeReminder result == Just i {reminder = (tail . reminder) i} &&
+              maybeTrace result == Just [pack $ show (typeRep (Proxy :: Proxy a))]))
     extractTail =
       property $ \(i :: Input) ->
         let result = runEndpoint tail' i

--- a/linnet/test/OutputSpec.hs
+++ b/linnet/test/OutputSpec.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module OutputSpec where
+
+import           Data.Data               (Proxy (..))
+import           Instances
+import           Linnet                  (Output)
+import           Test.Hspec
+import           Test.QuickCheck.Classes (applicativeLaws, foldableLaws,
+                                          functorLaws, monadLaws)
+import           Util
+
+spec :: Spec
+spec =
+  describe "OutputSpec" $ do
+    checkLaws "Output" $ functorLaws (Proxy :: Proxy Output)
+    checkLaws "Output" $ foldableLaws (Proxy :: Proxy Output)
+  --checkLaws "Output" $ monadLaws (Proxy :: Proxy Output)
+  --checkLaws "Output" $ applicativeLaws (Proxy :: Proxy Output)

--- a/linnet/test/Util.hs
+++ b/linnet/test/Util.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Util
@@ -22,16 +23,16 @@ headOption []    = Nothing
 headOption (h:t) = Just h
 
 resultOutputUnsafe :: (Applicative m) => EndpointResult m a -> m (Maybe (Output a))
-resultOutputUnsafe (Matched _ m)  = fmap Just m
+resultOutputUnsafe Matched {..}   = fmap Just matchedOutput
 resultOutputUnsafe (NotMatched _) = pure Nothing
 
 resultValueUnsafe :: (Applicative m) => EndpointResult m a -> m (Maybe a)
-resultValueUnsafe (Matched _ m) =
+resultValueUnsafe Matched {..} =
   fmap
     (\case
        Output _ (Payload a) _ -> Just a
        _ -> Nothing)
-    m
+    matchedOutput
 resultValueUnsafe (NotMatched _) = pure Nothing
 
 resultOutputEither :: (MonadCatch m) => EndpointResult m a -> m (Either SomeException (Maybe (Output a)))


### PR DESCRIPTION
- Add `matchedTracing` to `EndpointResult.Matched` that is just `type Trace = [Text]`
- Each `path*` endpoint adds tracing information into this list (constant value or name of the type)
- `Endpoint.productWith` merges tracing together with `++`
- In the end, it is compiled into
```haskell
type Compiled m = ReaderT (WriterT Trace m) Request (Either SomeException Response)
```
- In `toApp` all the left values are re-thrown in `IO`

It allows to have a tracing of endpoints on top of compiled reader, so things like logging and metrics get a nice gain for a price of additional allocations of tuple & either.